### PR TITLE
route AI calls through backend /api/ai endpoints

### DIFF
--- a/extension/src/background/service-worker.ts
+++ b/extension/src/background/service-worker.ts
@@ -9,7 +9,11 @@ import {
   getFlashcards,
   getAuthHeaders,
 } from '../shared/storage';
-import { callAI } from '../shared/ai';
+import {
+  explainWord as backendExplainWord,
+  translateSentence as backendTranslate,
+  explainSentence as backendExplainSentence,
+} from '../shared/backend-ai';
 import type { FlashcardPayload, LexemeEntry } from '../shared/types';
 import { populateDictionary, lookupTranslation } from './dictionary-db';
 
@@ -423,43 +427,12 @@ onMessage(async (msg, sender) => {
       const { word, sentence, context, level, requestId } = msg.payload;
       const tabId = sender.tab?.id;
       if (!tabId) return;
-
       try {
-        const stream = await callAI({
-          type: 'explain-word',
-          payload: { word, sentence, context: context ?? '', level },
-          stream: true,
-          requestId,
-        });
-
-        if (typeof stream === 'string') {
-          chrome.tabs.sendMessage(tabId, {
-            type: 'AI_STREAM_CHUNK',
-            payload: { requestId, chunk: stream },
-          }).catch(() => {});
-          chrome.tabs.sendMessage(tabId, {
-            type: 'AI_STREAM_DONE',
-            payload: { requestId },
-          }).catch(() => {});
-        } else {
-          const reader = (stream as ReadableStream<string>).getReader();
-          const pump = async (): Promise<void> => {
-            const { done, value } = await reader.read();
-            if (done) {
-              chrome.tabs.sendMessage(tabId, {
-                type: 'AI_STREAM_DONE',
-                payload: { requestId },
-              }).catch(() => {});
-              return;
-            }
-            chrome.tabs.sendMessage(tabId, {
-              type: 'AI_STREAM_CHUNK',
-              payload: { requestId, chunk: value },
-            }).catch(() => {});
-            await pump();
-          };
-          await pump();
-        }
+        const data = await backendExplainWord({ word, sentence, context, level });
+        chrome.tabs.sendMessage(tabId, {
+          type: 'AI_RESULT',
+          payload: { requestId, result: { kind: 'explain-word', data } },
+        }).catch(() => {});
       } catch (error) {
         chrome.tabs.sendMessage(tabId, {
           type: 'AI_STREAM_ERROR',
@@ -473,33 +446,17 @@ onMessage(async (msg, sender) => {
       const { sentence, level, requestId } = msg.payload;
       const tabId = sender.tab?.id;
       if (!tabId) return;
-
       try {
-        const stream = await callAI({
-          type: 'explain-sentence',
-          payload: { sentence, level },
-          stream: true,
-          requestId,
-        });
-
-        if (typeof stream === 'string') {
-          chrome.tabs.sendMessage(tabId, { type: 'AI_STREAM_CHUNK', payload: { requestId, chunk: stream } }).catch(() => {});
-          chrome.tabs.sendMessage(tabId, { type: 'AI_STREAM_DONE', payload: { requestId } }).catch(() => {});
-        } else {
-          const reader = (stream as ReadableStream<string>).getReader();
-          const pump = async (): Promise<void> => {
-            const { done, value } = await reader.read();
-            if (done) {
-              chrome.tabs.sendMessage(tabId, { type: 'AI_STREAM_DONE', payload: { requestId } }).catch(() => {});
-              return;
-            }
-            chrome.tabs.sendMessage(tabId, { type: 'AI_STREAM_CHUNK', payload: { requestId, chunk: value } }).catch(() => {});
-            await pump();
-          };
-          await pump();
-        }
+        const data = await backendExplainSentence({ sentence, level });
+        chrome.tabs.sendMessage(tabId, {
+          type: 'AI_RESULT',
+          payload: { requestId, result: { kind: 'explain-sentence', data } },
+        }).catch(() => {});
       } catch (error) {
-        chrome.tabs.sendMessage(tabId, { type: 'AI_STREAM_ERROR', payload: { requestId, error: (error as Error).message } }).catch(() => {});
+        chrome.tabs.sendMessage(tabId, {
+          type: 'AI_STREAM_ERROR',
+          payload: { requestId, error: (error as Error).message },
+        }).catch(() => {});
       }
       return { ok: true };
     }
@@ -508,18 +465,17 @@ onMessage(async (msg, sender) => {
       const { sentence, requestId } = msg.payload;
       const tabId = sender.tab?.id;
       if (!tabId) return;
-
       try {
-        const result = await callAI({
-          type: 'translate-sentence',
-          payload: { sentence },
-          stream: false,
-          requestId,
-        });
-        chrome.tabs.sendMessage(tabId, { type: 'AI_STREAM_CHUNK', payload: { requestId, chunk: result as string } }).catch(() => {});
-        chrome.tabs.sendMessage(tabId, { type: 'AI_STREAM_DONE', payload: { requestId } }).catch(() => {});
+        const data = await backendTranslate(sentence);
+        chrome.tabs.sendMessage(tabId, {
+          type: 'AI_RESULT',
+          payload: { requestId, result: { kind: 'translate', data } },
+        }).catch(() => {});
       } catch (error) {
-        chrome.tabs.sendMessage(tabId, { type: 'AI_STREAM_ERROR', payload: { requestId, error: (error as Error).message } }).catch(() => {});
+        chrome.tabs.sendMessage(tabId, {
+          type: 'AI_STREAM_ERROR',
+          payload: { requestId, error: (error as Error).message },
+        }).catch(() => {});
       }
       return { ok: true };
     }

--- a/extension/src/content/popup/WordPopup.tsx
+++ b/extension/src/content/popup/WordPopup.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { createRoot } from 'react-dom/client';
 import type { WordStatus, LexemeEntry, UserSettings } from '../../shared/types';
 import { sendMessage } from '../../shared/messages';
+import type { AiResultData } from '../../shared/backend-ai';
 import { lookupFrequency, getFrequencyBand } from '../../shared/frequency';
 import { StatusRow } from './StatusRow';
 import { PopupButtons } from './PopupButtons';
@@ -58,32 +59,99 @@ function FreqBadge({ rank }: { rank?: number }) {
   );
 }
 
-function AIPanel({ content, loading, error }: { content: string; loading: boolean; error?: string | null }) {
-  if (!content && !loading && !error) return null;
-
+function Field({ label, value }: { label: string; value?: string | null }) {
+  if (!value) return null;
   return (
-    <div style={{
-      background: C.surface0,
-      borderRadius: '6px',
-      padding: '8px 10px',
-      marginBottom: '8px',
-      fontSize: '12px',
-      color: C.text,
-      lineHeight: 1.6,
-      maxHeight: '200px',
-      overflowY: 'auto',
-      whiteSpace: 'pre-wrap',
-    }}>
-      {error ? (
-        <span style={{ color: C.red }}>{error}</span>
-      ) : loading && !content ? (
-        <span style={{ color: C.subtext }}>Thinking…</span>
-      ) : (
-        <span>{content}</span>
+    <div style={{ marginBottom: '6px' }}>
+      <div style={{ fontSize: '10px', fontWeight: 700, color: C.subtext, textTransform: 'uppercase', letterSpacing: '0.4px', marginBottom: '2px' }}>
+        {label}
+      </div>
+      <div style={{ color: C.text }}>{value}</div>
+    </div>
+  );
+}
+
+function AIPanel({ result, loading, error }: { result: AiResultData | null; loading: boolean; error?: string | null }) {
+  if (!result && !loading && !error) return null;
+
+  const wrap: React.CSSProperties = {
+    background: C.surface0,
+    borderRadius: '6px',
+    padding: '10px 12px',
+    marginBottom: '8px',
+    fontSize: '12px',
+    color: C.text,
+    lineHeight: 1.55,
+    maxHeight: '260px',
+    overflowY: 'auto',
+  };
+
+  if (error) {
+    return <div style={wrap}><span style={{ color: C.red }}>{error}</span></div>;
+  }
+
+  if (loading && !result) {
+    return <div style={wrap}><span style={{ color: C.subtext }}>Thinking…</span></div>;
+  }
+
+  if (!result) return null;
+
+  if (result.kind === 'explain-word') {
+    const d = result.data;
+    return (
+      <div style={wrap}>
+        <Field label="Meaning" value={d.meaning} />
+        <Field label="Part of Speech" value={d.partOfSpeech} />
+        <Field label="Usage Note" value={d.usageNote} />
+        <Field label="Common Mistake" value={d.commonMistake} />
+        {d.examples?.length > 0 && (
+          <div>
+            <div style={{ fontSize: '10px', fontWeight: 700, color: C.subtext, textTransform: 'uppercase', letterSpacing: '0.4px', marginBottom: '2px' }}>
+              Examples
+            </div>
+            <ul style={{ margin: 0, paddingLeft: '18px' }}>
+              {d.examples.map((ex, i) => <li key={i} style={{ marginBottom: '2px' }}>{ex}</li>)}
+            </ul>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (result.kind === 'translate') {
+    const d = result.data;
+    return (
+      <div style={wrap}>
+        <Field label="Natural" value={d.naturalTranslation} />
+        <Field label="Literal" value={d.literalTranslation} />
+        <Field label="Alternative" value={d.alternativeTranslation} />
+      </div>
+    );
+  }
+
+  // explain-sentence
+  const d = result.data;
+  return (
+    <div style={wrap}>
+      {d.parts?.length > 0 && (
+        <div style={{ marginBottom: '6px' }}>
+          <div style={{ fontSize: '10px', fontWeight: 700, color: C.subtext, textTransform: 'uppercase', letterSpacing: '0.4px', marginBottom: '2px' }}>
+            Parts
+          </div>
+          <ul style={{ margin: 0, paddingLeft: '18px' }}>
+            {d.parts.map((p, i) => (
+              <li key={i} style={{ marginBottom: '2px' }}>
+                <span style={{ fontWeight: 600 }}>{p.chunk}</span>
+                <span style={{ color: C.subtext }}> — {p.function}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
       )}
-      {loading && content && (
-        <span style={{ color: C.subtext, animation: 'none' }}>▊</span>
-      )}
+      <Field label="Turkish Meaning" value={d.turkishMeaning} />
+      <Field label="Grammar" value={d.grammarStructure} />
+      <Field label="Why This Structure" value={d.whyThisStructure} />
+      <Field label="Learner Tip" value={d.learnerTip} />
     </div>
   );
 }
@@ -100,7 +168,7 @@ function WordPopupInner({
   onStatusChange,
 }: WordPopupProps) {
   const [currentStatus, setCurrentStatus] = useState<WordStatus>(lexeme?.status ?? 'unknown');
-  const [aiContent, setAiContent] = useState('');
+  const [aiResult, setAiResult] = useState<AiResultData | null>(null);
   const [aiLoading, setAiLoading] = useState<AIActionType | null>(null);
   const [aiError, setAiError] = useState<string | null>(null);
   const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
@@ -222,15 +290,14 @@ function WordPopupInner({
     return () => document.removeEventListener('keydown', handler);
   }, [onClose]);
 
-  // Listen for AI stream messages
+  // Listen for AI result messages
   useEffect(() => {
-    const handler = (msg: { type: string; payload: { requestId: string; chunk?: string; error?: string } }) => {
+    const handler = (msg: { type: string; payload: { requestId: string; result?: AiResultData; error?: string } }) => {
       if (!requestIdRef.current) return;
       if (msg.payload?.requestId !== requestIdRef.current) return;
 
-      if (msg.type === 'AI_STREAM_CHUNK') {
-        setAiContent(prev => prev + (msg.payload.chunk ?? ''));
-      } else if (msg.type === 'AI_STREAM_DONE') {
+      if (msg.type === 'AI_RESULT' && msg.payload.result) {
+        setAiResult(msg.payload.result);
         setAiLoading(null);
         requestIdRef.current = null;
       } else if (msg.type === 'AI_STREAM_ERROR') {
@@ -253,7 +320,7 @@ function WordPopupInner({
   const handleAIAction = useCallback((type: AIActionType) => {
     const reqId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
     requestIdRef.current = reqId;
-    setAiContent('');
+    setAiResult(null);
     setAiError(null);
     setAiLoading(type);
 
@@ -506,7 +573,7 @@ function WordPopupInner({
       )}
 
       {/* AI output panel */}
-      <AIPanel content={aiContent} loading={aiLoading !== null} error={aiError} />
+      <AIPanel result={aiResult} loading={aiLoading !== null} error={aiError} />
 
       {/* Status row */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', borderTop: `1px solid ${C.surface1}`, paddingTop: '10px' }}>

--- a/extension/src/shared/backend-ai.ts
+++ b/extension/src/shared/backend-ai.ts
@@ -1,0 +1,96 @@
+import { getSettings } from './storage';
+import type { LearnerLevel } from './types';
+
+const DEFAULT_BACKEND_URL = 'https://syntagma.omerhanyigit.online';
+
+export interface AiWordExplainData {
+  meaning: string;
+  partOfSpeech: string;
+  usageNote: string;
+  commonMistake: string;
+  examples: string[];
+}
+
+export interface AiTranslateData {
+  naturalTranslation: string;
+  literalTranslation: string;
+  alternativeTranslation: string;
+}
+
+export interface AiSentencePart {
+  chunk: string;
+  function: string;
+}
+
+export interface AiSentenceExplainData {
+  parts: AiSentencePart[];
+  turkishMeaning: string;
+  grammarStructure: string;
+  whyThisStructure: string;
+  learnerTip: string;
+}
+
+export type AiResultKind = 'explain-word' | 'translate' | 'explain-sentence';
+
+export type AiResultData =
+  | { kind: 'explain-word'; data: AiWordExplainData }
+  | { kind: 'translate'; data: AiTranslateData }
+  | { kind: 'explain-sentence'; data: AiSentenceExplainData };
+
+interface ApiEnvelope<T> {
+  status: string;
+  data: T;
+  message?: string;
+  errorCode?: string;
+}
+
+async function postJson<T>(path: string, body: unknown): Promise<T> {
+  const settings = await getSettings();
+  const base = (settings.apiBaseUrl || DEFAULT_BACKEND_URL).replace(/\/+$/, '');
+  if (!settings.authToken) {
+    throw new Error('Sign in to use AI features');
+  }
+  const res = await fetch(`${base}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${settings.authToken}`,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    let msg = `AI request failed (${res.status})`;
+    try {
+      const err = await res.json() as { message?: string };
+      if (err?.message) msg = err.message;
+    } catch { /* ignore */ }
+    throw new Error(msg);
+  }
+  const json = await res.json() as ApiEnvelope<T>;
+  if (json.status !== 'success' || !json.data) {
+    throw new Error(json.message ?? 'AI request failed');
+  }
+  return json.data;
+}
+
+export function explainWord(input: {
+  word: string;
+  sentence: string;
+  context?: string;
+  level: LearnerLevel;
+  exampleCount?: number;
+}): Promise<AiWordExplainData> {
+  return postJson<AiWordExplainData>('/api/ai/explain-word', input);
+}
+
+export function translateSentence(sentence: string): Promise<AiTranslateData> {
+  return postJson<AiTranslateData>('/api/ai/translate', { sentence });
+}
+
+export function explainSentence(input: {
+  sentence: string;
+  level: LearnerLevel;
+  context?: string;
+}): Promise<AiSentenceExplainData> {
+  return postJson<AiSentenceExplainData>('/api/ai/explain-sentence', input);
+}

--- a/extension/src/shared/messages.ts
+++ b/extension/src/shared/messages.ts
@@ -1,4 +1,5 @@
 import type { WordStatus, LearnerLevel, UserSettings, FlashcardPayload } from './types';
+import type { AiResultData } from './backend-ai';
 
 export type ExtensionMessage =
   | { type: 'PARSE_PAGE_FOR_COMPREHENSION'; payload: { tabId: number; pageUrl: string } }
@@ -35,6 +36,7 @@ export type BackgroundMessage =
   | { type: 'AI_STREAM_CHUNK'; payload: { requestId: string; chunk: string } }
   | { type: 'AI_STREAM_DONE'; payload: { requestId: string } }
   | { type: 'AI_STREAM_ERROR'; payload: { requestId: string; error: string } }
+  | { type: 'AI_RESULT'; payload: { requestId: string; result: AiResultData } }
   | { type: 'STATUS_CHANGED'; payload: { lemma: string; status: WordStatus } }
   | { type: 'BULK_STATUS_CHANGED'; payload: { lemmas: string[]; status: WordStatus } }
   | { type: 'SETTINGS_UPDATED'; payload: Partial<UserSettings> };


### PR DESCRIPTION
 Replace direct OpenRouter calls with a backend client that posts to
  /api/ai/explain-word, /api/ai/translate, and /api/ai/explain-sentence
  The service worker now emits a single AI_RESULT
  message carrying structured data, and WordPopup renders it as labeled
  fields (meaning, part of speech, examples,translations, sentence parts, grammar notes) instead of streamed plaintext.