### PR TITLE
Add DTOs for known words and daily cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,8 +104,3 @@ diff_report.txt
 # Large local-only files
 extension/dictionary.json
 .codex
-/backend
-/backend
-/backend
-/backend
-/backend

--- a/backend/src/main/java/com/syntagma/backend/dto/request/KnownWordsIntakeRequest.java
+++ b/backend/src/main/java/com/syntagma/backend/dto/request/KnownWordsIntakeRequest.java
@@ -1,0 +1,9 @@
+package com.syntagma.backend.dto.request;
+
+import java.util.List;
+import jakarta.validation.constraints.NotEmpty;
+
+public record KnownWordsIntakeRequest(
+        @NotEmpty
+        List<String> knownWords
+) {}

--- a/backend/src/main/java/com/syntagma/backend/dto/request/LevelKnownWordsRequest.java
+++ b/backend/src/main/java/com/syntagma/backend/dto/request/LevelKnownWordsRequest.java
@@ -1,0 +1,8 @@
+package com.syntagma.backend.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LevelKnownWordsRequest(
+        @NotBlank
+        String level
+) {}

--- a/backend/src/main/java/com/syntagma/backend/dto/response/DailyCardsResponse.java
+++ b/backend/src/main/java/com/syntagma/backend/dto/response/DailyCardsResponse.java
@@ -1,0 +1,23 @@
+package com.syntagma.backend.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record DailyCardsResponse(
+        int dueCount,
+        int newCount,
+        List<DailyCardItem> cards
+) {
+    public record DailyCardItem(
+            Long flashcardId,
+            String lemma,
+            String translation,
+            String type,
+            LocalDateTime nextReviewAt,
+            Float stability,
+            Float difficulty,
+            String state,
+            Integer reps,
+            Integer lapses
+    ) {}
+}


### PR DESCRIPTION
Add request and response DTO records used by the backend API: KnownWordsIntakeRequest (List<String> knownWords, @NotEmpty), LevelKnownWordsRequest (String level, @NotBlank), and DailyCardsResponse with nested DailyCardItem (flashcardId, lemma, translation, type, nextReviewAt, stability, difficulty, state, reps, lapses). Also clean up duplicate /backend entries in .gitignore. These DTOs prepare the server for endpoints handling known-words intake, level selection, and daily card responses.