### PR TITLE
  Fix video player popup, contraction handling, add stats, remove inl…

### DIFF
--- a/extension/src/content/header-bar.tsx
+++ b/extension/src/content/header-bar.tsx
@@ -28,7 +28,7 @@ export interface HeaderBarState {
   shiftMode: boolean;
   onParse: () => void;
   onToggleColors: (val: boolean) => void;
-  onToggleTranslations: (val: boolean) => void;
+
   onOpenSettings: () => void;
   onQuickAddCard: (lemma: string, sentence: string) => Promise<void>;
   onOpenAdvancedCreator: (lemma?: string, sentence?: string) => void;
@@ -74,14 +74,13 @@ interface ToastMsg { text: string; ok: boolean; id: number }
 
 function TopBar({
   settings, tokens, lexemes, shiftMode,
-  onToggleColors, onToggleTranslations, onOpenSettings,
+  onToggleColors, onOpenSettings,
   onOpenAdvancedCreator,
 }: HeaderBarState) {
   const tt = useT(settings);
   const [collapsed, setCollapsed] = useState(false);
   const [locked, setLocked] = useState(false);
   const [colorsOn, setColorsOn] = useState(settings.showLearningStatusColors);
-  const [trOn, setTrOn] = useState(settings.showInlineTranslations);
   const [showStats, setShowStats] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [inVideoMode, setInVideoMode] = useState(false);
@@ -125,7 +124,7 @@ function TopBar({
 
   useEffect(() => {
     setColorsOn(settings.showLearningStatusColors);
-    setTrOn(settings.showInlineTranslations);
+
   }, [settings]);
 
   const showToast = useCallback((text: string, ok: boolean) => {
@@ -141,11 +140,7 @@ function TopBar({
     onToggleColors(v);
   }, [colorsOn, onToggleColors]);
 
-  const handleToggleTr = useCallback(() => {
-    const v = !trOn;
-    setTrOn(v);
-    onToggleTranslations(v);
-  }, [trOn, onToggleTranslations]);
+
 
   // Alt+X locks toolbar
   useEffect(() => {
@@ -267,14 +262,7 @@ function TopBar({
           </svg>
         </IconBtn>
 
-        {/* Translator / Inline TR */}
-        <IconBtn title={tt('header.toggleTranslations')} active={trOn} color={C.blue} onClick={handleToggleTr}>
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="m5 8 6 6" /><path d="m4 14 6-6 2-3" />
-            <path d="M2 5h12" /><path d="M7 2h1" />
-            <path d="m22 22-5-10-5 10" /><path d="M14 18h6" />
-          </svg>
-        </IconBtn>
+
 
         {/* Lock toolbar */}
         <IconBtn title={locked ? tt('header.unlockToolbar') : tt('header.lockToolbar')} active={locked} color={C.subtext} onClick={() => setLocked(l => !l)}>

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -86,7 +86,7 @@ function refreshHeader(overrides: Partial<Parameters<typeof mountHeaderBar>[0]> 
     shiftMode,
     onParse: handleParse,
     onToggleColors: handleToggleColors,
-    onToggleTranslations: handleToggleTranslations,
+
     onOpenSettings: handleOpenSettings,
     onQuickAddCard: handleQuickAddCard,
     onOpenAdvancedCreator: handleOpenAdvancedCreator,
@@ -127,7 +127,7 @@ async function init() {
       shiftMode: false,
       onParse: handleParse,
       onToggleColors: handleToggleColors,
-      onToggleTranslations: handleToggleTranslations,
+  
       onOpenSettings: handleOpenSettings,
       onQuickAddCard: handleQuickAddCard,
       onOpenAdvancedCreator: handleOpenAdvancedCreator,

--- a/extension/src/content/parser.ts
+++ b/extension/src/content/parser.ts
@@ -29,11 +29,14 @@ const CONTRACTIONS: Record<string, string[]> = {
   "they'd": ['they', 'would'], "we'd": ['we', 'would'], "you'd": ['you', 'would'],
 };
 
+// Normalize all apostrophe-like Unicode chars to ASCII apostrophe
+const APOSTROPHE_RE = /[''‚‛′ʹʼʻ`]/g;
+
 function resolveContractionStatus(
   surface: string,
   lexemes: Record<string, { status: WordStatus }>,
 ): WordStatus | null {
-  const normalized = surface.toLowerCase().replace(/['']/g, "'");
+  const normalized = surface.toLowerCase().replace(APOSTROPHE_RE, "'");
   const parts = CONTRACTIONS[normalized];
   if (!parts) return null;
   const statuses = parts.map(l => lexemes[l]?.status ?? 'unknown');
@@ -43,7 +46,8 @@ function resolveContractionStatus(
 }
 
 // Only process tokens that look like English words (latin alphabet)
-const ENGLISH_WORD_RE = /^[a-zA-Z]{2,}(?:[''][a-zA-Z]+)?$/;
+// Allow single-letter prefix for contractions like I'm, I've, I'll, I'd
+const ENGLISH_WORD_RE = /^[a-zA-Z]+(?:[''][a-zA-Z]+)?$/;
 
 export interface ParseResult {
   tokens: Token[];
@@ -81,15 +85,17 @@ function getSentenceContext(textNode: Text): string {
 }
 
 export function tokenizeText(text: string): Array<{ surface: string; startOffset: number; endOffset: number }> {
+  const normalized = text.replace(APOSTROPHE_RE, "'");
   const tokens: Array<{ surface: string; startOffset: number; endOffset: number }> = [];
-  // Match word tokens (including apostrophes for contractions like "don't")
-  const wordRe = /[a-zA-Z]{2,}(?:[''][a-zA-Z]+)?/g;
+  // Match word tokens including contractions (I'm, don't, you've, etc.)
+  const wordRe = /[a-zA-Z]+(?:'[a-zA-Z]+)?/g;
   let match: RegExpExecArray | null;
-  while ((match = wordRe.exec(text)) !== null) {
+  while ((match = wordRe.exec(normalized)) !== null) {
     const surface = match[0];
-    if (surface.length >= MIN_WORD_LENGTH && ENGLISH_WORD_RE.test(surface)) {
+    const isContraction = surface.includes("'") && CONTRACTIONS[surface.toLowerCase()] !== undefined;
+    if ((surface.length >= MIN_WORD_LENGTH || isContraction) && ENGLISH_WORD_RE.test(surface)) {
       tokens.push({
-        surface,
+        surface: text.slice(match.index, match.index + surface.length),
         startOffset: match.index,
         endOffset: match.index + surface.length,
       });

--- a/extension/src/content/popup/WordPopup.tsx
+++ b/extension/src/content/popup/WordPopup.tsx
@@ -6,6 +6,7 @@ import type { AiResultData } from '../../shared/backend-ai';
 import { lookupFrequency, getFrequencyBand } from '../../shared/frequency';
 import { StatusRow } from './StatusRow';
 import { PopupButtons } from './PopupButtons';
+import { CONTRACTION_EXPANSIONS } from '../video/tokenizer';
 
 const C = {
   base: '#F5F1E9',
@@ -172,6 +173,8 @@ function WordPopupInner({
   onClose,
   onStatusChange,
 }: WordPopupProps) {
+  const contractionExpansion = CONTRACTION_EXPANSIONS[lemma.toLowerCase().replace(/[''‚‛′ʹʼʻ`]/g, "'")]
+    ?? CONTRACTION_EXPANSIONS[surface.toLowerCase().replace(/[''‚‛′ʹʼʻ`]/g, "'")];
   const [currentStatus, setCurrentStatus] = useState<WordStatus>(lexeme?.status ?? 'unknown');
   const [aiResult, setAiResult] = useState<AiResultData | null>(null);
   const [aiLoading, setAiLoading] = useState<AIActionType | null>(null);
@@ -511,10 +514,12 @@ function WordPopupInner({
           {/* Headword */}
           <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '2px' }}>
             <span style={{ fontSize: '18px', fontWeight: 700, color: C.text }}>{surface}</span>
-            {surface.toLowerCase() !== lemma && (
+            {contractionExpansion ? (
+              <span style={{ fontSize: '12px', color: C.blue, fontWeight: 600 }}>= {contractionExpansion}</span>
+            ) : surface.toLowerCase() !== lemma ? (
               <span style={{ fontSize: '12px', color: C.subtext }}>({lemma})</span>
-            )}
-            <FreqBadge rank={freqEntry?.rank} />
+            ) : null}
+            {!contractionExpansion && <FreqBadge rank={freqEntry?.rank} />}
           </div>
           {/* Turkish meaning if available */}
           {lexeme?.trMeaning && (

--- a/extension/src/content/video/VideoSidebarPanel.tsx
+++ b/extension/src/content/video/VideoSidebarPanel.tsx
@@ -4,7 +4,7 @@ import { parseSubtitleFile } from './subtitle-parser';
 import { mountWordPopup, dismissWordPopup } from '../popup/WordPopup';
 import { buildSentences } from './sentence-grouping';
 import type { SentenceGroup } from './sentence-grouping';
-import { tokenize } from './tokenizer';
+import { tokenize, CONTRACTION_EXPANSIONS } from './tokenizer';
 
 // ─── Memoized sentence row ────────────────────────────────────────────────────
 
@@ -154,7 +154,8 @@ const CueRow = memo(function CueRow({ sentence, isActive, selected, lexemes, sho
                worst === 'learning' ? 'rgba(233, 196, 106,0.55)' :
                'transparent')
             : 'transparent';
-          const clickLemma = lookups[0];
+          const normForm = tok.text.toLowerCase().replace(/[''‚‛′ʹʼʻ`]/g, "'");
+          const clickLemma = CONTRACTION_EXPANSIONS[normForm] ? normForm : lookups[0];
           return (
             <span
               key={ti}

--- a/extension/src/content/video/tokenizer.ts
+++ b/extension/src/content/video/tokenizer.ts
@@ -6,6 +6,29 @@ export interface TextToken {
   lemmas?: string[];
 }
 
+// Normalize all apostrophe-like Unicode chars to ASCII apostrophe
+const APOSTROPHE_RE = /[‘’‚‛′ʹʼʻ`]/g;
+function normalizeApostrophes(s: string): string {
+  return s.replace(APOSTROPHE_RE, "'");
+}
+
+// Human-readable expansion for display in popups
+export const CONTRACTION_EXPANSIONS: Record<string, string> = {
+  "i'm": "I am", "i'll": "I will", "i've": "I have", "i'd": "I would",
+  "it's": "it is", "that's": "that is", "what's": "what is",
+  "there's": "there is", "here's": "here is", "who's": "who is",
+  "he's": "he is", "she's": "she is", "let's": "let us",
+  "won't": "will not", "can't": "cannot", "don't": "do not",
+  "doesn't": "does not", "didn't": "did not", "isn't": "is not",
+  "aren't": "are not", "wasn't": "was not", "weren't": "were not",
+  "hasn't": "has not", "haven't": "have not", "hadn't": "had not",
+  "wouldn't": "would not", "couldn't": "could not", "shouldn't": "should not",
+  "they're": "they are", "we're": "we are", "you're": "you are",
+  "they've": "they have", "we've": "we have", "you've": "you have",
+  "they'll": "they will", "we'll": "we will", "you'll": "you will",
+  "they'd": "they would", "we'd": "we would", "you'd": "you would",
+};
+
 const CONTRACTIONS: Record<string, string[]> = {
   "i'm": ['i', 'be'], "i'll": ['i', 'will'], "i've": ['i', 'have'], "i'd": ['i', 'would'],
   "it's": ['it', 'be'], "that's": ['that', 'be'], "what's": ['what', 'be'],
@@ -22,21 +45,54 @@ const CONTRACTIONS: Record<string, string[]> = {
   "they'd": ['they', 'would'], "we'd": ['we', 'would'], "you'd": ['you', 'would'],
 };
 
+// Suffix-only fallback: if tokenizer splits a contraction (e.g. "I" + "'ve"),
+// map the orphaned suffix to its full-word lemma so it inherits known status.
+const CONTRACTION_SUFFIXES: Record<string, string[]> = {
+  "'m": ['be'], "'re": ['be'], "'s": ['be'],
+  "'ve": ['have'], "'ll": ['will'], "'d": ['would'],
+  "n't": ['not'],
+};
+
 export function tokenize(text: string): TextToken[] {
-  const raw = text
-    .split(/(\b[a-zA-Z''']+\b)/)
+  const norm = normalizeApostrophes(text);
+  const raw = norm
+    .split(/(\b[a-zA-Z']+\b)/)
     .filter(p => p.length > 0);
 
   const out: TextToken[] = [];
-  for (const p of raw) {
-    const normalized = p.replace(/['']/g, "'").toLowerCase();
+  for (let i = 0; i < raw.length; i++) {
+    const p = raw[i];
+    const normalized = p.replace(/'/g, "'").toLowerCase();
     const expansion = CONTRACTIONS[normalized];
     if (expansion) {
       out.push({ text: p, isWord: true, lemmas: expansion });
-    } else if (/^[a-zA-Z''']+$/.test(p)) {
+      continue;
+    }
+
+    // Handle orphaned suffix: if previous token was a word and this starts
+    // with an apostrophe, try to merge or map the suffix.
+    if (normalized.startsWith("'") && normalized.length > 1) {
+      const suffixLemmas = CONTRACTION_SUFFIXES[normalized];
+      if (suffixLemmas) {
+        // Try to merge with previous word token for a contraction lookup
+        const prev = out.length > 0 ? out[out.length - 1] : null;
+        if (prev && prev.isWord) {
+          const merged = (prev.text + p).replace(/'/g, "'").toLowerCase();
+          const mergedNorm = normalizeApostrophes(merged).toLowerCase();
+          const mergedExpansion = CONTRACTIONS[mergedNorm];
+          if (mergedExpansion) {
+            prev.text = prev.text + p;
+            prev.lemmas = mergedExpansion;
+            continue;
+          }
+        }
+        out.push({ text: p, isWord: true, lemmas: suffixLemmas });
+        continue;
+      }
+    }
+
+    if (/^[a-zA-Z']+$/.test(p)) {
       const lower = normalized.replace(/'/g, "'");
-      // For words ending in 's not in the contractions map (e.g. "something's",
-      // "everyone's"), include the base form so status inherits from the root.
       if (lower.endsWith("'s") && lower.length > 2) {
         const base = lower.slice(0, -2);
         const baseLemma = lemmatize(base);

--- a/extension/src/options/OptionsApp.tsx
+++ b/extension/src/options/OptionsApp.tsx
@@ -286,7 +286,6 @@ function GeneralTab({ settings, onUpdate }: { settings: UserSettings; onUpdate: 
       <SectionTitle>{_('opt.display')}</SectionTitle>
       <Toggle value={settings.showComprehensionHeader} onChange={v => onUpdate({ showComprehensionHeader: v })} label={_('opt.showHeader')} />
       <Toggle value={settings.showLearningStatusColors} onChange={v => onUpdate({ showLearningStatusColors: v })} label={_('opt.showStatusColors')} description={_('opt.statusColorDesc')} />
-      <Toggle value={settings.showInlineTranslations} onChange={v => onUpdate({ showInlineTranslations: v })} label={_('opt.showInlineTr')} />
 
       <Select
         label={_('opt.yourLevel')}

--- a/extension/src/reader-page/ReaderApp.tsx
+++ b/extension/src/reader-page/ReaderApp.tsx
@@ -6,6 +6,7 @@ import { DEFAULT_SETTINGS, userScopedKey, getAuthHeaders } from '../shared/stora
 import { sendMessage } from '../shared/messages';
 import { lookupFrequency, initFrequencyTable } from '../shared/frequency';
 import { lemmatize } from '../shared/lemmatizer';
+import { CONTRACTION_EXPANSIONS } from '../content/video/tokenizer';
 import { usePageAnalysis } from '../content/hooks/usePageAnalysis';
 import { MiniDonut, StatsPopup, StatsUIColors } from '../content/components/StatsUI';
 import { collectWholeBookAnalysisFromBuffer } from './reader-analysis';
@@ -253,6 +254,39 @@ async function updateEbookProgress(ebookId: string, lastPage: number): Promise<v
   }
 }
 
+// ─── Contraction handling ──────────────────────────────────────────────────
+
+const APOSTROPHE_RE = /[''‚‛′ʹʼʻ`]/g;
+
+const CONTRACTIONS: Record<string, string[]> = {
+  "i'm": ['i', 'be'], "i'll": ['i', 'will'], "i've": ['i', 'have'], "i'd": ['i', 'would'],
+  "it's": ['it', 'be'], "that's": ['that', 'be'], "what's": ['what', 'be'],
+  "there's": ['there', 'be'], "here's": ['here', 'be'], "who's": ['who', 'be'],
+  "he's": ['he', 'be'], "she's": ['she', 'be'], "let's": ['let', 'us'],
+  "won't": ['will', 'not'], "can't": ['can', 'not'], "don't": ['do', 'not'],
+  "doesn't": ['do', 'not'], "didn't": ['do', 'not'], "isn't": ['be', 'not'],
+  "aren't": ['be', 'not'], "wasn't": ['be', 'not'], "weren't": ['be', 'not'],
+  "hasn't": ['have', 'not'], "haven't": ['have', 'not'], "hadn't": ['have', 'not'],
+  "wouldn't": ['would', 'not'], "couldn't": ['could', 'not'], "shouldn't": ['should', 'not'],
+  "they're": ['they', 'be'], "we're": ['we', 'be'], "you're": ['you', 'be'],
+  "they've": ['they', 'have'], "we've": ['we', 'have'], "you've": ['you', 'have'],
+  "they'll": ['they', 'will'], "we'll": ['we', 'will'], "you'll": ['you', 'will'],
+  "they'd": ['they', 'would'], "we'd": ['we', 'would'], "you'd": ['you', 'would'],
+};
+
+function resolveContractionStatus(
+  surface: string,
+  lexemes: Record<string, { status: WordStatus }>,
+): WordStatus | null {
+  const normalized = surface.toLowerCase().replace(APOSTROPHE_RE, "'");
+  const parts = CONTRACTIONS[normalized];
+  if (!parts) return null;
+  const statuses = parts.map(l => lexemes[l]?.status ?? 'unknown');
+  if (statuses.includes('unknown')) return 'unknown';
+  if (statuses.includes('learning')) return 'learning';
+  return 'known';
+}
+
 // ─── Word interaction helpers ───────────────────────────────────────────────
 
 function getStatusColor(status: WordStatus): string | undefined {
@@ -278,30 +312,36 @@ function wrapWordsInElement(container: Document, lexemes: Record<string, LexemeE
   }
 
   for (const textNode of textNodes) {
-    const text = textNode.textContent ?? '';
-    // Regex matches words (letters, apostrophes, hyphens) and everything else as segments
-    const segments = text.split(/([a-zA-Z]{2,}(?:[''][a-zA-Z]+)?)/);
+    const rawText = textNode.textContent ?? '';
+    const text = rawText.replace(APOSTROPHE_RE, "'");
+    const segments = text.split(/([a-zA-Z]+(?:'[a-zA-Z]+)?)/);
     if (segments.length <= 1) continue;
 
     const frag = container.createDocumentFragment();
-    for (const segment of segments) {
-      // Check if segment is a word (matches our regex)
-      if (/^[a-zA-Z]{2,}(?:[''][a-zA-Z]+)?$/.test(segment)) {
+    for (let si = 0; si < segments.length; si++) {
+      const segment = segments[si];
+      const normalized = segment.toLowerCase();
+      const isContraction = CONTRACTIONS[normalized] !== undefined;
+      if ((segment.length >= 2 || isContraction) && /^[a-zA-Z]+(?:'[a-zA-Z]+)?$/.test(segment)) {
+        const contractionStatus = resolveContractionStatus(segment, lexemes);
         const lemma = lemmatize(segment);
         const entry = lexemes[lemma];
-        const status = entry?.status ?? 'unknown';
-        
+        const status = contractionStatus ?? entry?.status ?? 'unknown';
+
         tokens.push({ surface: segment, lemma, status });
-        
+
         const span = container.createElement('span');
-        span.textContent = segment;
+        span.textContent = rawText.slice(
+          text.indexOf(segment, segments.slice(0, si).join('').length),
+          text.indexOf(segment, segments.slice(0, si).join('').length) + segment.length
+        );
         span.dataset.syntagmaWord = lemma;
         span.dataset.surface = segment;
+        if (isContraction) span.dataset.contraction = normalized;
         span.style.cursor = 'pointer';
         span.style.transition = 'background-color 0.1s, border-color 0.1s';
-        
+
         if (settings.readerShowLearningStatusColors) {
-          const status = entry?.status ?? 'unknown';
           span.style.borderBottom = getUnderlineStyle(status);
         } else {
           span.style.borderBottom = '2px solid transparent';
@@ -717,9 +757,13 @@ function ReaderWordPopup({
         <div>
           <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '2px' }}>
             <span style={{ fontSize: '18px', fontWeight: 700, color: PC.text }}>{surface}</span>
-            {surface.toLowerCase() !== word && (
-              <span style={{ fontSize: '12px', color: PC.subtext }}>({word})</span>
-            )}
+            {(() => {
+              const normForm = surface.toLowerCase().replace(APOSTROPHE_RE, "'");
+              const expansion = CONTRACTION_EXPANSIONS[normForm] ?? CONTRACTION_EXPANSIONS[word];
+              if (expansion) return <span style={{ fontSize: '12px', color: PC.subtext }}>= {expansion}</span>;
+              if (surface.toLowerCase() !== word) return <span style={{ fontSize: '12px', color: PC.subtext }}>({word})</span>;
+              return null;
+            })()}
             {freqEntry && (
               <span style={{ background: PC.surface1, color: PC.subtext, borderRadius: '3px', padding: '1px 5px', fontSize: '10px', fontWeight: 600 }}>
                 #{freqEntry.rank}
@@ -1251,7 +1295,8 @@ function ReaderView({
           const span = target.closest('span[data-syntagma-word]') as HTMLElement;
           
           if (span) {
-            const word = span.dataset.syntagmaWord!;
+            const contraction = span.dataset.contraction;
+            const word = contraction ?? span.dataset.syntagmaWord!;
             const surface = span.dataset.surface || word;
             const sentence = extractSentence(span);
             

--- a/extension/src/video-player-page/VideoPlayerApp.tsx
+++ b/extension/src/video-player-page/VideoPlayerApp.tsx
@@ -6,10 +6,15 @@ import { sendMessage } from '../shared/messages';
 import { parseSubtitleFile } from '../content/video/subtitle-parser';
 import { buildSentences } from '../content/video/sentence-grouping';
 import type { SentenceGroup } from '../content/video/sentence-grouping';
-import { lookupFrequency } from '../shared/frequency';
+import { lookupFrequency, getFrequencyBand } from '../shared/frequency';
 import { initFrequencyTable } from '../shared/frequency';
-import { tokenize } from '../content/video/tokenizer';
+import { tokenize, CONTRACTION_EXPANSIONS } from '../content/video/tokenizer';
 import { useT, LocaleToggle, type UILocale } from '../shared/i18n';
+import type { AiResultData } from '../shared/backend-ai';
+import { PopupButtons } from '../content/popup/PopupButtons';
+import { StatusRow } from '../content/popup/StatusRow';
+import { MiniDonut, StatsPopup } from '../content/components/StatsUI';
+import type { PageAnalysis } from '../content/hooks/usePageAnalysis';
 
 // ─── Theme (warm, matches extension) ─────────────────────────────────────────
 
@@ -356,7 +361,8 @@ const CueRow = memo(function CueRow({ sentence, isActive, selected, lexemes, sho
                worst === 'learning' ? 'rgba(233,196,106,0.55)' :
                'transparent')
             : 'transparent';
-          const clickLemma = lookups[0];
+          const normForm = tok.text.toLowerCase().replace(/[''‚‛′ʹʼʻ`]/g, "'");
+          const clickLemma = CONTRACTION_EXPANSIONS[normForm] ? normForm : lookups[0];
           return (
             <span
               key={ti}
@@ -393,6 +399,126 @@ interface WordPopupState {
 
 
 
+type AIActionType = 'explain-word' | 'explain-sentence' | 'translate';
+
+function FreqBadge({ rank }: { rank?: number }) {
+  if (!rank) return null;
+  const band = getFrequencyBand(rank);
+  const colors: Record<string, string> = {
+    'very-common': C.green,
+    'common': C.blue,
+    'medium': C.amber,
+    'rare': C.subtext,
+  };
+  return (
+    <span style={{
+      background: C.surface1,
+      color: colors[band] ?? C.subtext,
+      borderRadius: '3px',
+      padding: '1px 5px',
+      fontSize: '10px',
+      fontWeight: 600,
+    }}>
+      #{rank}
+    </span>
+  );
+}
+
+function Field({ label, value }: { label: string; value?: string | null }) {
+  if (!value) return null;
+  return (
+    <div style={{ marginBottom: '6px' }}>
+      <div style={{ fontSize: '10px', fontWeight: 700, color: C.subtext, textTransform: 'uppercase', letterSpacing: '0.4px', marginBottom: '2px' }}>
+        {label}
+      </div>
+      <div style={{ color: C.text }}>{value}</div>
+    </div>
+  );
+}
+
+function AIPanel({ result, loading, error }: { result: AiResultData | null; loading: boolean; error?: string | null }) {
+  if (!result && !loading && !error) return null;
+
+  const wrap: React.CSSProperties = {
+    background: C.surface0,
+    borderRadius: '6px',
+    padding: '10px 12px',
+    marginBottom: '8px',
+    fontSize: '12px',
+    color: C.text,
+    lineHeight: 1.55,
+    maxHeight: '260px',
+    overflowY: 'auto',
+  };
+
+  if (error) {
+    return <div style={wrap}><span style={{ color: C.red }}>{error}</span></div>;
+  }
+
+  if (loading && !result) {
+    return <div style={wrap}><span style={{ color: C.subtext }}>Thinking…</span></div>;
+  }
+
+  if (!result) return null;
+
+  if (result.kind === 'explain-word') {
+    const d = result.data;
+    return (
+      <div style={wrap}>
+        <Field label="Meaning" value={d.meaning} />
+        <Field label="Part of Speech" value={d.partOfSpeech} />
+        <Field label="Usage Note" value={d.usageNote} />
+        <Field label="Common Mistake" value={d.commonMistake} />
+        {d.examples?.length > 0 && (
+          <div>
+            <div style={{ fontSize: '10px', fontWeight: 700, color: C.subtext, textTransform: 'uppercase', letterSpacing: '0.4px', marginBottom: '2px' }}>
+              Examples
+            </div>
+            <ul style={{ margin: 0, paddingLeft: '18px' }}>
+              {d.examples.map((ex: string, i: number) => <li key={i} style={{ marginBottom: '2px' }}>{ex}</li>)}
+            </ul>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (result.kind === 'translate') {
+    const d = result.data;
+    return (
+      <div style={wrap}>
+        <Field label="Çeviri" value={d.naturalTranslation} />
+      </div>
+    );
+  }
+
+  // explain-sentence
+  const d = result.data;
+  return (
+    <div style={wrap}>
+      {d.parts?.length > 0 && (
+        <div style={{ marginBottom: '6px' }}>
+          <div style={{ fontSize: '10px', fontWeight: 700, color: C.subtext, textTransform: 'uppercase', letterSpacing: '0.4px', marginBottom: '2px' }}>
+            Parts
+          </div>
+          <ul style={{ margin: 0, paddingLeft: '18px' }}>
+            {d.parts.map((p: { chunk: string; function: string }, i: number) => (
+              <li key={i} style={{ marginBottom: '2px' }}>
+                <span style={{ fontWeight: 600 }}>{p.chunk}</span>
+                <span style={{ color: C.subtext }}> — {p.function}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <Field label="Turkish Meaning" value={d.turkishMeaning} />
+      <Field label="Grammar" value={d.grammarStructure} />
+      <Field label="Why This Structure" value={d.whyThisStructure} />
+      <Field label="Learner Tip" value={d.learnerTip} />
+    </div>
+  );
+}
+
 function VideoWordPopup({
   popup, lexemes, settings, videoName, videoRef, audioRef, audioSrc,
   captureAudio,
@@ -410,16 +536,21 @@ function VideoWordPopup({
   onStatusChange: (lemma: string, status: WordStatus) => void;
 }) {
   const { word, surface, sentence, anchorRect } = popup;
+  const contractionExpansion = CONTRACTION_EXPANSIONS[word.toLowerCase().replace(/[''‚‛′ʹʼʻ`]/g, "'")];
   const lexeme = lexemes[word] ?? null;
   const [currentStatus, setCurrentStatus] = useState<WordStatus>(lexeme?.status ?? 'unknown');
   const [translations, setTranslations] = useState<string[]>([]);
   const [cardSaved, setCardSaved] = useState<'idle' | 'saving' | 'done' | 'error'>('idle');
   const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
   const [isDragging, setIsDragging] = useState(false);
+  const [aiResult, setAiResult] = useState<AiResultData | null>(null);
+  const [aiLoading, setAiLoading] = useState<AIActionType | null>(null);
+  const [aiError, setAiError] = useState<string | null>(null);
   const popupRef = useRef<HTMLDivElement>(null);
   const isDraggingRef = useRef(false);
   const dragOffsetRef = useRef({ x: 0, y: 0 });
   const wasPlayingRef = useRef(false);
+  const requestIdRef = useRef<string | null>(null);
   const freqEntry = lookupFrequency(word);
 
   // Pause video on mount, resume on unmount (close)
@@ -523,12 +654,26 @@ function VideoWordPopup({
     return () => document.removeEventListener('keydown', handler);
   }, [onClose]);
 
-  const STATUS_CONFIG: Array<{ status: WordStatus; color: string; label: string }> = [
-    { status: 'unknown', color: C.red, label: 'Unknown' },
-    { status: 'learning', color: C.amber, label: 'Learning' },
-    { status: 'known', color: C.green, label: 'Known' },
-    { status: 'ignored', color: C.subtext, label: 'Ignore' },
-  ];
+  // Listen for AI result messages
+  useEffect(() => {
+    const handler = (msg: { type: string; payload: { requestId: string; result?: AiResultData; error?: string } }) => {
+      if (!requestIdRef.current) return;
+      if (msg.payload?.requestId !== requestIdRef.current) return;
+
+      if (msg.type === 'AI_RESULT' && msg.payload.result) {
+        setAiResult(msg.payload.result);
+        setAiLoading(null);
+        requestIdRef.current = null;
+      } else if (msg.type === 'AI_STREAM_ERROR') {
+        setAiError(msg.payload.error ?? 'AI error');
+        setAiLoading(null);
+        requestIdRef.current = null;
+      }
+    };
+
+    chrome.runtime.onMessage.addListener(handler);
+    return () => chrome.runtime.onMessage.removeListener(handler);
+  }, []);
 
   const handleStatusChange = useCallback((status: WordStatus) => {
     setCurrentStatus(status);
@@ -536,11 +681,39 @@ function VideoWordPopup({
     sendMessage({ type: 'SET_WORD_STATUS', payload: { lemma: word, status } }).catch(console.error);
   }, [word, onStatusChange]);
 
-  const handleCycleStatus = useCallback(() => {
-    const idx = STATUS_CONFIG.findIndex(c => c.status === currentStatus);
-    const next = STATUS_CONFIG[(idx + 1) % STATUS_CONFIG.length];
-    handleStatusChange(next.status);
-  }, [currentStatus, handleStatusChange]);
+  const handleAIAction = useCallback((type: AIActionType) => {
+    const reqId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    requestIdRef.current = reqId;
+    setAiResult(null);
+    setAiError(null);
+    setAiLoading(type);
+
+    if (type === 'explain-word') {
+      sendMessage({
+        type: 'EXPLAIN_WORD_WITH_AI',
+        payload: { word, sentence, level: settings.learnerLevel, requestId: reqId },
+      }).catch(err => {
+        setAiError((err as Error).message);
+        setAiLoading(null);
+      });
+    } else if (type === 'explain-sentence') {
+      sendMessage({
+        type: 'EXPLAIN_SENTENCE_WITH_AI',
+        payload: { sentence, level: settings.learnerLevel, requestId: reqId },
+      }).catch(err => {
+        setAiError((err as Error).message);
+        setAiLoading(null);
+      });
+    } else if (type === 'translate') {
+      sendMessage({
+        type: 'TRANSLATE_SENTENCE_WITH_AI',
+        payload: { sentence, requestId: reqId },
+      }).catch(err => {
+        setAiError((err as Error).message);
+        setAiLoading(null);
+      });
+    }
+  }, [word, sentence, settings.learnerLevel]);
 
   const handleSaveCard = useCallback(async () => {
     if (cardSaved !== 'idle') return;
@@ -616,23 +789,12 @@ function VideoWordPopup({
     }).catch(() => {});
   }, [word, sentence, popup.startMs, popup.endMs, videoName, lexeme, translations, videoRef, captureAudio]);
 
-  const currentCfg = STATUS_CONFIG.find(c => c.status === currentStatus) ?? STATUS_CONFIG[0];
-
-  const btnStyle = (active?: boolean, color?: string): React.CSSProperties => ({
-    width: '32px', height: '32px', borderRadius: '16px',
-    display: 'flex', alignItems: 'center', justifyContent: 'center',
-    background: active ? (color ?? C.blue) : 'transparent',
-    color: active ? C.base : (color ?? C.blue),
-    border: `1.5px solid ${color ?? C.blue}`,
-    cursor: 'pointer', padding: 0, transition: 'all 0.15s', flexShrink: 0,
-  });
-
   return (
     <div ref={popupRef} style={{
       position: 'fixed', zIndex: 2147483645, width: '340px',
       background: C.overlay, backdropFilter: 'blur(12px)',
       border: `1px solid ${C.surface1}`, borderRadius: '8px',
-      padding: '12px', boxShadow: '0 8px 32px rgba(0,0,0,0.15)',
+      padding: '12px', boxShadow: '0 8px 32px rgba(0,0,0,0.6)',
       fontFamily: 'system-ui, -apple-system, sans-serif', fontSize: '13px', color: C.text,
       ...(position ? { top: position.top, left: position.left } : { top: -9999, left: -9999, visibility: 'hidden' as const }),
       ...(isDragging ? { userSelect: 'none' as const, cursor: 'grabbing' } : {}),
@@ -657,51 +819,54 @@ function VideoWordPopup({
         <div>
           <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '2px' }}>
             <span style={{ fontSize: '18px', fontWeight: 700, color: C.text }}>{surface}</span>
-            {surface.toLowerCase() !== word && (
+            {contractionExpansion ? (
+              <span style={{ fontSize: '12px', color: C.blue, fontWeight: 600 }}>= {contractionExpansion}</span>
+            ) : surface.toLowerCase() !== word ? (
               <span style={{ fontSize: '12px', color: C.subtext }}>({word})</span>
-            )}
-            {freqEntry && (
-              <span style={{ background: C.surface1, color: C.subtext, borderRadius: '3px', padding: '1px 5px', fontSize: '10px', fontWeight: 600 }}>
-                #{freqEntry.rank}
-              </span>
-            )}
+            ) : null}
+            {!contractionExpansion && <FreqBadge rank={freqEntry?.rank} />}
           </div>
           {lexeme?.trMeaning && (
             <div style={{ fontSize: '12px', color: C.blue, fontStyle: 'italic' }}>{lexeme.trMeaning}</div>
           )}
         </div>
-        <div style={{ display: 'flex', gap: '6px', flexShrink: 0 }}>
+        <div style={{ display: 'flex', gap: '6px' }}>
           <button
             onClick={handleSaveCard}
-            title={!settings.authToken ? 'Log in to save cards' : cardSaved === 'done' ? 'Card saved!' : 'Quick add to flashcards'}
-            disabled={!settings.authToken || cardSaved !== 'idle'}
+            title={!settings.authToken ? 'Log in to save cards' : cardSaved === 'done' ? 'Card saved!' : cardSaved === 'error' ? 'Save failed' : 'Quick add to flashcards'}
+            disabled={!settings.authToken || cardSaved === 'saving'}
             style={{
-              height: '28px', borderRadius: '14px',
-              display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '5px',
-              background: cardSaved === 'done' ? C.green : cardSaved === 'error' ? C.red : cardSaved === 'saving' ? C.amber : C.green,
-              color: C.base, border: 'none',
+              width: '32px',
+              height: '32px',
+              borderRadius: '16px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: cardSaved === 'done' ? C.green : cardSaved === 'error' ? C.red : C.green,
+              color: C.base,
+              border: 'none',
               cursor: cardSaved === 'idle' ? 'pointer' : 'default',
-              padding: '0 10px', transition: 'background 0.2s', flexShrink: 0,
-              fontSize: '11px', fontWeight: 700,
+              padding: 0,
+              transition: 'background 0.2s',
+              flexShrink: 0,
             }}
           >
             {cardSaved === 'done' ? (
-              <>
-                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
-                Saved!
-              </>
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="20 6 9 17 4 12"></polyline>
+              </svg>
             ) : cardSaved === 'error' ? (
-              <>
-                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
-                Error
-              </>
-            ) : cardSaved === 'saving' ? (
-              <>Saving...</>
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18"></line>
+                <line x1="6" y1="6" x2="18" y2="18"></line>
+              </svg>
             ) : (
-              <>
-                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><polyline points="14 2 14 8 20 8" /><line x1="12" y1="18" x2="12" y2="12" /><line x1="9" y1="15" x2="15" y2="15" /></svg>
-                Save
-              </>
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                <polyline points="14 2 14 8 20 8"></polyline>
+                <line x1="12" y1="18" x2="12" y2="12"></line>
+                <line x1="9" y1="15" x2="15" y2="15"></line>
+              </svg>
             )}
           </button>
           <button
@@ -709,11 +874,19 @@ function VideoWordPopup({
             title={!settings.authToken ? 'Log in to edit cards' : 'Open in card creator'}
             disabled={!settings.authToken}
             style={{
-              width: '32px', height: '32px', borderRadius: '16px',
-              display: 'flex', alignItems: 'center', justifyContent: 'center',
-              background: C.blue, color: C.base, border: 'none',
+              width: '32px',
+              height: '32px',
+              borderRadius: '16px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: C.blue,
+              color: C.base,
+              border: 'none',
               cursor: settings.authToken ? 'pointer' : 'default',
-              padding: 0, transition: 'background 0.2s', flexShrink: 0,
+              padding: 0,
+              transition: 'background 0.2s',
+              flexShrink: 0,
             }}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
@@ -730,11 +903,11 @@ function VideoWordPopup({
           display: 'flex', alignItems: 'center', gap: '6px',
           background: cardSaved === 'done' ? C.green + '22' : C.red + '22',
           border: `1px solid ${cardSaved === 'done' ? C.green : C.red}`,
-          borderRadius: '5px', padding: '5px 9px', marginBottom: '8px',
-          fontSize: '12px', fontWeight: 600,
+          borderRadius: '5px', padding: '5px 9px',
+          marginBottom: '8px', fontSize: '12px', fontWeight: 600,
           color: cardSaved === 'done' ? C.green : C.red,
         }}>
-          {cardSaved === 'done' ? 'Card saved to your flashcards!' : 'Failed to save card. Try again.'}
+          {cardSaved === 'done' ? '✓ Card saved to your flashcards!' : '✕ Failed to save card. Try again.'}
         </div>
       )}
 
@@ -743,22 +916,21 @@ function VideoWordPopup({
         <div style={{
           background: C.surface0, borderRadius: '4px', padding: '6px 8px',
           marginBottom: '8px', fontSize: '12px', color: C.subtext,
-          lineHeight: 1.5, fontStyle: 'italic', maxHeight: '80px', overflowY: 'auto',
+          lineHeight: 1.5, fontStyle: 'italic', maxHeight: '120px', overflowY: 'auto',
         }}>
           {sentence}
         </div>
       )}
 
-      {/* Pronounce button */}
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px', marginBottom: '12px' }}>
-        <button onClick={() => {
-          const u = new SpeechSynthesisUtterance(surface);
-          u.lang = 'en-US'; u.rate = 0.85;
-          window.speechSynthesis.speak(u);
-        }} style={btnStyle(false, C.green)} title="Pronounce word">
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polygon points="5 3 19 12 5 21 5 3" /></svg>
-        </button>
-      </div>
+      {/* Action buttons (pronounce, AI explain word, AI explain sentence, translate, external links) */}
+      <PopupButtons
+        word={word}
+        sentence={sentence}
+        level={settings.learnerLevel}
+        audioUrl={lexeme?.audioUrl}
+        onAIAction={handleAIAction}
+        aiLoading={aiLoading}
+      />
 
       {/* Dictionary translations */}
       {translations.length > 0 && (
@@ -767,16 +939,15 @@ function VideoWordPopup({
         </ul>
       )}
 
+      {/* AI output panel */}
+      <AIPanel result={aiResult} loading={aiLoading !== null} error={aiError} />
+
       {/* Status row */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', borderTop: `1px solid ${C.surface1}`, paddingTop: '10px' }}>
-        <button onClick={handleCycleStatus} title="Click to cycle status" style={{
-          background: currentCfg.color, color: C.base, border: 'none', borderRadius: '16px',
-          padding: '6px 12px', cursor: 'pointer', fontSize: '12px', fontWeight: 800,
-          transition: 'all 0.15s', display: 'flex', alignItems: 'center', gap: '6px',
-          textTransform: 'uppercase', letterSpacing: '0.5px',
-        }}>
-          {currentCfg.label}
-        </button>
+        <StatusRow
+          currentStatus={currentStatus}
+          onStatusChange={handleStatusChange}
+        />
       </div>
     </div>
   );
@@ -806,6 +977,8 @@ export function VideoPlayerApp() {
   const [subPosition, setSubPosition] = useState<'bottom' | 'top'>('bottom');
   const [showSettingsDrawer, setShowSettingsDrawer] = useState(false);
   const [isSubRevealed, setIsSubRevealed] = useState(false);
+  const [showStats, setShowStats] = useState(false);
+  const statsRef = useRef<HTMLButtonElement>(null);
 
   const videoRef = useRef<HTMLVideoElement>(null);
   const audioRef = useRef<HTMLAudioElement>(null);
@@ -822,6 +995,46 @@ export function VideoPlayerApp() {
     () => rolling ? buildSentencesFromRolling(cues) : buildSentences(cues),
     [cues, rolling],
   );
+
+  // Analyse subtitle tokens for the stats donut
+  const subtitleAnalysis: PageAnalysis = useMemo(() => {
+    if (sentences.length === 0) {
+      return { comprehensionScore: 0, iPlusOneSentences: 0, unknownWords: [], counts: { total: 0, known: 0, learning: 0, unknown: 0 } };
+    }
+    let known = 0, learning = 0, unknown = 0;
+    let iPlusOne = 0;
+    const unknownMap = new Map<string, { lemma: string; surface: string; occurrences: number; frequencyRank?: number }>();
+
+    for (const s of sentences) {
+      const tokens = tokenize(s.text);
+      const sentenceUnknowns = new Set<string>();
+      for (const tok of tokens) {
+        if (!tok.isWord) continue;
+        const lookups = tok.lemmas ?? [tok.text.toLowerCase()];
+        const statuses = lookups.map(l => lexemes[l]?.status);
+        if (statuses.includes('ignored')) continue;
+        if (statuses.includes('known')) { known++; }
+        else if (statuses.includes('learning')) { learning++; }
+        else {
+          unknown++;
+          const lemma = lookups[0];
+          sentenceUnknowns.add(lemma);
+          const entry = unknownMap.get(lemma);
+          if (entry) { entry.occurrences++; }
+          else {
+            const freq = lookupFrequency(lemma);
+            unknownMap.set(lemma, { lemma, surface: tok.text, occurrences: 1, frequencyRank: freq?.rank });
+          }
+        }
+      }
+      if (sentenceUnknowns.size === 1) iPlusOne++;
+    }
+
+    const total = known + learning + unknown;
+    const score = total > 0 ? Math.round(((known + 0.5 * learning) / total) * 100) : 0;
+    const unknownWords = [...unknownMap.values()].sort((a, b) => b.occurrences - a.occurrences);
+    return { comprehensionScore: score, iPlusOneSentences: iPlusOne, unknownWords, counts: { total, known, learning, unknown } };
+  }, [sentences, lexemes]);
 
   const toggleSelect = useCallback((key: string) => {
     setSelectedKeys(prev => {
@@ -1192,11 +1405,46 @@ export function VideoPlayerApp() {
           display: 'flex', alignItems: 'center', justifyContent: 'space-between',
           padding: '8px 16px', background: C.surface0,
           borderBottom: `1px solid ${C.surface1}`, flexShrink: 0,
+          position: 'relative',
         }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: '1px' }}>
             <span style={{ color: C.blue, fontWeight: 800, fontSize: '16px' }}>Syn</span>
             <span style={{ color: C.amber, fontWeight: 800, fontSize: '16px' }}>tagma</span>
             <span style={{ color: C.subtext, fontSize: '13px', marginLeft: '6px' }}>{_('video.videoPlayer')}</span>
+
+            {/* Stats trigger — mini donut + % score (always visible once subtitles loaded) */}
+            <button
+              ref={statsRef}
+              onClick={() => { if (sentences.length > 0) setShowStats(v => !v); }}
+              title="Page Analysis"
+              style={{
+                background: showStats ? C.surface1 : 'transparent',
+                border: `1px solid ${showStats ? C.surface1 : 'transparent'}`,
+                borderRadius: '8px',
+                display: 'flex', alignItems: 'center', gap: '6px',
+                padding: '4px 8px', marginLeft: '10px',
+                cursor: sentences.length > 0 ? 'pointer' : 'default',
+                transition: 'all 0.15s', flexShrink: 0,
+              }}
+            >
+              <MiniDonut
+                known={subtitleAnalysis.counts.known}
+                learning={subtitleAnalysis.counts.learning}
+                unknown={subtitleAnalysis.counts.unknown}
+                total={subtitleAnalysis.counts.total}
+              />
+              {subtitleAnalysis.comprehensionScore > 0 ? (
+                <span style={{
+                  fontWeight: 700, fontSize: '13px',
+                  color: subtitleAnalysis.comprehensionScore >= 90 ? C.green
+                    : subtitleAnalysis.comprehensionScore >= 70 ? C.amber : C.red,
+                }}>
+                  {subtitleAnalysis.comprehensionScore}%
+                </span>
+              ) : (
+                <span style={{ fontSize: '12px', color: C.subtext }}>—</span>
+              )}
+            </button>
           </div>
           <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
             <LocaleToggle settings={settings} onToggle={handleLocaleToggle} />
@@ -1220,6 +1468,17 @@ export function VideoPlayerApp() {
             >{_('video.loadSubtitles')}</button>
           </div>
         </div>
+
+        {/* Stats popup (fixed overlay, triggered from top bar donut) */}
+        {showStats && subtitleAnalysis.counts.total > 0 && (
+          <StatsPopup
+            analysis={subtitleAnalysis}
+            anchorLeft={statsRef.current ? statsRef.current.getBoundingClientRect().left : 80}
+            onClose={() => setShowStats(false)}
+            isFixed={true}
+            title="Page Analysis"
+          />
+        )}
 
         {/* Video area */}
         <div data-video-area="" style={{
@@ -1311,7 +1570,8 @@ export function VideoPlayerApp() {
                   const underline = settings.showLearningStatusColors
                     ? (worst === 'unknown' ? C.red : worst === 'learning' ? C.amber : 'transparent')
                     : 'transparent';
-                  const clickLemma = lookups[0];
+                  const normForm = tok.text.toLowerCase().replace(/[''‚‛′ʹʼʻ`]/g, "'");
+          const clickLemma = CONTRACTION_EXPANSIONS[normForm] ? normForm : lookups[0];
                   return (
                     <span key={i}
                       onClick={e => handleOverlayWordClick(clickLemma, tok.text, activeOverlayTextProcessed, (e.currentTarget as HTMLElement).getBoundingClientRect())}
@@ -1448,7 +1708,8 @@ export function VideoPlayerApp() {
               </button>
             )}
           </div>
-        </div>
+
+          </div>
 
         {/* Hint row */}
         {cues.length > 0 && (


### PR DESCRIPTION
…ine translations

  Video player:
  - Word popup now matches YouTube/Netflix format with AI buttons (explain, translate, sentence), icon-only save button, StatusRow
  - Added page analysis stats donut in header bar next to "Video Player" text with click-to-open StatsPopup overlay
  - Fixed contraction click to show "= I have" style expansion

  Contraction handling (all page types):
  - Tokenizer normalizes Unicode apostrophes before splitting
  - Orphaned suffixes ('ve, 'm, 're) merge back with previous token
  - Contractions resolve status from component words (I + have = known)
  - Parser allows single-letter prefix for contractions like I'm, I've

  Ebook reader:
  - Added full contraction support matching web page and video player
  - Regex now captures contractions and single-letter words like "I"
  - Word popup shows "= I have" expansion for contractions
  - Click handler passes contraction form for correct popup display

  Removed inline translations:
  - Removed toggle button from header bar
  - Removed showInlineTranslations toggle from settings page